### PR TITLE
feat: Add pagination support to sync and search endpoints

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -891,12 +891,12 @@
         },
         "stage0-py-utils": {
             "hashes": [
-                "sha256:189fafd1674ad83376bb69a755f12c310c1db62407a0ba0af7cce067fd49b5b9",
-                "sha256:906600dae23cde8d5420bc4b6065bd7ce31b9ce9b53abf63bde16e306ac34222"
+                "sha256:57d1b42543ce1ee18b45c60b1a7f20fddb289d33b5fcdf0c0d8994031334433d",
+                "sha256:caeaba506b52ae56b879bf94e4cdf5ca990564f621de7f5d309a0ec33f8a19f0"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==0.2.11"
+            "version": "==0.2.13"
         },
         "typing-extensions": {
             "hashes": [

--- a/source/routes/search_routes.py
+++ b/source/routes/search_routes.py
@@ -1,7 +1,7 @@
 import logging
 from flask import Blueprint, request, jsonify
 from source.services.search_services import SearchServices
-from stage0_py_utils import create_flask_breadcrumb, create_flask_token
+from stage0_py_utils import create_flask_breadcrumb, create_flask_token, Config
 
 logger = logging.getLogger(__name__)
 
@@ -10,20 +10,36 @@ search_bp = Blueprint('search', __name__)
 
 @search_bp.route('/search/', methods=['GET'])
 def search_documents():
-    """Search documents using query or search parameters."""
+    """Search documents using query or search parameters with pagination support."""
     token = create_flask_token()
     breadcrumb = create_flask_breadcrumb(token)
+    config = Config.get_instance()
     
     # Get query parameters
     query_param = request.args.get('query')
     search_param = request.args.get('search')
     
-    # Perform search
+    # Get pagination parameters
+    page = request.args.get('page', 1, type=int)
+    page_size = request.args.get('page_size', config.PAGE_SIZE, type=int)
+    
+    # Validate pagination parameters
+    if page < 1:
+        logger.warning(f"{breadcrumb} Invalid page parameter: {page}")
+        return jsonify({}), 400
+    
+    if page_size < 1 or page_size > 100:
+        logger.warning(f"{breadcrumb} Invalid page_size parameter: {page_size}")
+        return jsonify({}), 400
+    
+    # Perform search with pagination
     results = SearchServices.search_documents(
         query_param=query_param,
         search_param=search_param,
+        page=page,
+        page_size=page_size,
         token=token,
         breadcrumb=breadcrumb
     )
-    logger.info(f"{breadcrumb} Successfully performed search with {len(results)} results")
+    logger.info(f"{breadcrumb} Successfully performed search page {page} with {page_size} items")
     return jsonify(results) 

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -4,6 +4,7 @@ import urllib.parse
 from unittest.mock import Mock, patch
 from flask import Flask
 from source.routes.search_routes import search_bp
+from stage0_py_utils import Config
 
 class TestSearchRoutes(unittest.TestCase):
     
@@ -17,8 +18,18 @@ class TestSearchRoutes(unittest.TestCase):
     @patch('source.services.search_services.SearchServices.search_documents')
     def test_search_documents_with_query(self, mock_search_documents):
         """Test search documents endpoint with query parameter."""
-        # Mock the service response
-        mock_results = [{"id": "doc1", "title": "Test Document"}]
+        page_size = Config.get_instance().PAGE_SIZE
+        mock_results = {
+            "items": [{"id": "doc1", "title": "Test Document"}],
+            "pagination": {
+                "page": 1,
+                "page_size": page_size,
+                "total_items": 1,
+                "total_pages": 1,
+                "has_next": False,
+                "has_previous": False
+            }
+        }
         mock_search_documents.return_value = mock_results
         
         # Test with URL-encoded JSON query
@@ -30,7 +41,9 @@ class TestSearchRoutes(unittest.TestCase):
         # Verify response
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data)
-        self.assertEqual(data, mock_results)
+        self.assertIn("items", data)
+        self.assertIn("pagination", data)
+        self.assertEqual(data["items"], mock_results["items"])
         
         # Verify service was called with token/breadcrumb
         mock_search_documents.assert_called_once()
@@ -42,8 +55,18 @@ class TestSearchRoutes(unittest.TestCase):
     @patch('source.services.search_services.SearchServices.search_documents')
     def test_search_documents_with_search_text(self, mock_search_documents):
         """Test search documents endpoint with search parameter."""
-        # Mock the service response
-        mock_results = [{"id": "doc1", "title": "Test Document"}]
+        page_size = Config.get_instance().PAGE_SIZE
+        mock_results = {
+            "items": [{"id": "doc1", "title": "Test Document"}],
+            "pagination": {
+                "page": 1,
+                "page_size": page_size,
+                "total_items": 1,
+                "total_pages": 1,
+                "has_next": False,
+                "has_previous": False
+            }
+        }
         mock_search_documents.return_value = mock_results
         
         # Test with URL-encoded search text
@@ -55,7 +78,9 @@ class TestSearchRoutes(unittest.TestCase):
         # Verify response
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data)
-        self.assertEqual(data, mock_results)
+        self.assertIn("items", data)
+        self.assertIn("pagination", data)
+        self.assertEqual(data["items"], mock_results["items"])
         
         # Verify service was called with token/breadcrumb
         mock_search_documents.assert_called_once()
@@ -63,6 +88,48 @@ class TestSearchRoutes(unittest.TestCase):
         self.assertEqual(call_args[1]['search_param'], search_text)
         self.assertIn('token', call_args[1])
         self.assertIn('breadcrumb', call_args[1])
+
+    @patch('source.services.search_services.SearchServices.search_documents')
+    def test_search_documents_with_pagination(self, mock_search_documents):
+        """Test search documents endpoint with pagination parameters."""
+        # Mock the service response
+        mock_results = {
+            "items": [{"id": "doc2", "title": "Test Document 2"}],
+            "pagination": {
+                "page": 2,
+                "page_size": 5,
+                "total_items": 25,
+                "total_pages": 5,
+                "has_next": True,
+                "has_previous": True
+            }
+        }
+        mock_search_documents.return_value = mock_results
+        
+        response = self.client.get('/api/search/?search=test&page=2&page_size=5')
+        
+        # Verify response
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertIn("items", data)
+        self.assertIn("pagination", data)
+        self.assertEqual(data["pagination"]["page"], 2)
+        self.assertEqual(data["pagination"]["page_size"], 5)
+
+    def test_search_documents_invalid_page(self):
+        """Test search documents endpoint with invalid page parameter."""
+        response = self.client.get('/api/search/?search=test&page=0')
+        self.assertEqual(response.status_code, 400)
+
+    def test_search_documents_invalid_page_size(self):
+        """Test search documents endpoint with invalid page_size parameter."""
+        response = self.client.get('/api/search/?search=test&page_size=0')
+        self.assertEqual(response.status_code, 400)
+
+    def test_search_documents_page_size_too_large(self):
+        """Test search documents endpoint with page_size too large."""
+        response = self.client.get('/api/search/?search=test&page_size=101')
+        self.assertEqual(response.status_code, 400)
 
 if __name__ == '__main__':
     unittest.main() 

--- a/tests/routes/test_sync_routes.py
+++ b/tests/routes/test_sync_routes.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from flask import Flask, json
 from source.routes.sync_routes import sync_bp
 from source.services.sync_services import SyncError
+from stage0_py_utils import Config
 
 class TestSyncRoutes(unittest.TestCase):
     def setUp(self):
@@ -13,17 +14,77 @@ class TestSyncRoutes(unittest.TestCase):
 
     @patch('source.services.sync_services.SyncServices.get_sync_history')
     def test_get_sync_history(self, mock_get_sync_history):
-        mock_get_sync_history.return_value = [{"id": "sync_1"}]
+        page_size = Config.get_instance().PAGE_SIZE
+        mock_get_sync_history.return_value = {
+            "items": [{"id": "sync_1"}],
+            "pagination": {
+                "page": 1,
+                "page_size": page_size,
+                "total_items": 1,
+                "total_pages": 1,
+                "has_next": False,
+                "has_previous": False
+            }
+        }
         response = self.client.get('/api/sync/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get_json(), [{"id": "sync_1"}])
+        result = response.get_json()
+        self.assertIn("items", result)
+        self.assertIn("pagination", result)
+        self.assertEqual(result["items"], [{"id": "sync_1"}])
 
     @patch('source.services.sync_services.SyncServices.get_sync_history')
     def test_get_sync_history_with_limit(self, mock_get_sync_history):
-        mock_get_sync_history.return_value = [{"id": "sync_1"}]
+        mock_get_sync_history.return_value = {
+            "items": [{"id": "sync_1"}],
+            "pagination": {
+                "page": 1,
+                "page_size": 5,
+                "total_items": 1,
+                "total_pages": 1,
+                "has_next": False,
+                "has_previous": False
+            }
+        }
         response = self.client.get('/api/sync/?limit=5')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get_json(), [{"id": "sync_1"}])
+        result = response.get_json()
+        self.assertIn("items", result)
+        self.assertIn("pagination", result)
+
+    @patch('source.services.sync_services.SyncServices.get_sync_history')
+    def test_get_sync_history_with_pagination(self, mock_get_sync_history):
+        page_size = Config.get_instance().PAGE_SIZE
+        mock_get_sync_history.return_value = {
+            "items": [{"id": "sync_2"}],
+            "pagination": {
+                "page": 2,
+                "page_size": page_size,
+                "total_items": 25,
+                "total_pages": 3,
+                "has_next": True,
+                "has_previous": True
+            }
+        }
+        response = self.client.get(f'/api/sync/?page=2&page_size={page_size}')
+        self.assertEqual(response.status_code, 200)
+        result = response.get_json()
+        self.assertIn("items", result)
+        self.assertIn("pagination", result)
+        self.assertEqual(result["pagination"]["page"], 2)
+        self.assertEqual(result["pagination"]["page_size"], page_size)
+
+    def test_get_sync_history_invalid_page(self):
+        response = self.client.get('/api/sync/?page=0')
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_sync_history_invalid_page_size(self):
+        response = self.client.get('/api/sync/?page_size=0')
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_sync_history_page_size_too_large(self):
+        response = self.client.get('/api/sync/?page_size=101')
+        self.assertEqual(response.status_code, 400)
 
     @patch('source.services.sync_services.SyncServices.get_sync_periodicity')
     def test_get_sync_periodicity(self, mock_get_sync_periodicity):


### PR DESCRIPTION
- Add pagination parameters (page, page_size) to GET /api/sync/ and GET /api/search/
- Use Config.PAGE_SIZE as default page size for consistent behavior
- Update sync and search services to handle pagination logic
- Enhance Elasticsearch utils to support pagination in queries
- Add comprehensive test coverage for pagination functionality
- All unit tests and StepCI end-to-end tests passing
- Container build tested and ready for deployment